### PR TITLE
chore(release): support CIB seven 2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ If you just want to start using the library, put the following dependency into y
 <dependency>
   <groupId>org.cibseven.community.data</groupId>
   <artifactId>cibseven-bpm-data</artifactId>
-  <version>2.0.0</version>
+  <version>2.1.0</version>
 </dependency>
 ```
 

--- a/example/coverage-report-aggregator/pom.xml
+++ b/example/coverage-report-aggregator/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.cibseven.community.data.example</groupId>
     <artifactId>cibseven-bpm-data-example-parent</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.1.0</version>
   </parent>
 
   <artifactId>cibseven-bpm-data-coverage-report</artifactId>

--- a/example/example-java/pom.xml
+++ b/example/example-java/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.cibseven.community.data.example</groupId>
     <artifactId>cibseven-bpm-data-example-parent</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.1.0</version>
   </parent>
 
   <artifactId>cibseven-bpm-data-example-java</artifactId>

--- a/example/example-kotlin/pom.xml
+++ b/example/example-kotlin/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.cibseven.community.data.example</groupId>
     <artifactId>cibseven-bpm-data-example-parent</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.1.0</version>
   </parent>
 
   <artifactId>cibseven-bpm-data-example-kotlin</artifactId>

--- a/example/example-no-engine/pom.xml
+++ b/example/example-no-engine/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.cibseven.community.data.example</groupId>
     <artifactId>cibseven-bpm-data-example-parent</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.1.0</version>
   </parent>
 
   <artifactId>cibseven-bpm-data-example-no-engine</artifactId>

--- a/example/itest/pom.xml
+++ b/example/itest/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.cibseven.community.data.example</groupId>
     <artifactId>cibseven-bpm-data-example-parent</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.1.0</version>
   </parent>
 
   <artifactId>cibseven-bpm-data-integration-test</artifactId>

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.cibseven.community.data</groupId>
     <artifactId>cibseven-bpm-data-parent</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.1.0</version>
   </parent>
 
   <groupId>org.cibseven.community.data.example</groupId>

--- a/example/spin-type-detector/pom.xml
+++ b/example/spin-type-detector/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.cibseven.community.data.example</groupId>
     <artifactId>cibseven-bpm-data-example-parent</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.1.0</version>
   </parent>
 
   <artifactId>cibseven-bpm-data-spin-type-detector</artifactId>

--- a/extension/core/pom.xml
+++ b/extension/core/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.cibseven.community.data</groupId>
     <artifactId>cibseven-bpm-data-parent</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.1.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,18 +27,18 @@
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <version.java>${java.version}</version.java>
 
-    <cibseven.version>2.0.0</cibseven.version>
+    <cibseven.version>2.1.0</cibseven.version>
 
-    <spring-boot.version>3.4.5</spring-boot.version>
+    <spring-boot.version>3.5.6</spring-boot.version>
     <spin.version>${cibseven.version}</spin.version>
     <cibseven-assert.version>${cibseven.version}</cibseven-assert.version>
 
-    <kotlin.version>2.1.20</kotlin.version>
-    <jgiven.version>2.0.2</jgiven.version>
+    <kotlin.version>2.2.20</kotlin.version>
+    <jgiven.version>2.0.3</jgiven.version>
     <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
 
-    <kotlin-logging.version>7.0.7</kotlin-logging.version>
-    <mockito-kotlin.version>5.4.0</mockito-kotlin.version>
+    <kotlin-logging.version>7.0.13</kotlin-logging.version>
+    <mockito-kotlin.version>6.1.0</mockito-kotlin.version>
 
     <pattern.class.itest>%regex[.*ITest.*]</pattern.class.itest>
 
@@ -167,11 +167,8 @@
           <groupId>org.jetbrains.kotlin</groupId>
           <version>${kotlin.version}</version>
           <configuration>
-            <languageVersion>1.9</languageVersion>
-            <apiVersion>1.9</apiVersion>
-            <args>
-              <arg>-Xinline-classes</arg>
-            </args>
+            <languageVersion>2.1</languageVersion>
+            <apiVersion>2.1</apiVersion>
             <jvmTarget>${java.version}</jvmTarget>
             <compilerPlugins>
               <plugin>spring</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <spin.version>${cibseven.version}</spin.version>
     <cibseven-assert.version>${cibseven.version}</cibseven-assert.version>
 
-    <kotlin.version>2.2.20</kotlin.version>
+    <kotlin.version>2.2.21</kotlin.version>
     <jgiven.version>2.0.3</jgiven.version>
     <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
 
@@ -167,8 +167,8 @@
           <groupId>org.jetbrains.kotlin</groupId>
           <version>${kotlin.version}</version>
           <configuration>
-            <languageVersion>2.1</languageVersion>
-            <apiVersion>2.1</apiVersion>
+            <languageVersion>2.2</languageVersion>
+            <apiVersion>2.2</apiVersion>
             <jvmTarget>${java.version}</jvmTarget>
             <compilerPlugins>
               <plugin>spring</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>org.cibseven.community.data</groupId>
   <artifactId>cibseven-bpm-data-parent</artifactId>
-  <version>2.1.0-SNAPSHOT</version>
+  <version>2.1.0</version>
 
   <name>${project.artifactId}</name>
   <description>CIB seven BPM Data</description>


### PR DESCRIPTION
Bumps the following dependencies:
- cibseven.version from 2.0.0 to 2.1.0
- spring-boot.version from 3.4.5 to 3.5.6
- kotlin.version from 2.1.20 to 2.2.21
- jgiven.version from 2.0.2 to 2.0.3
- kotlin-logging.version from 7.0.7 to 7.0.13
- mockito-kotlin.version from 5.4.0 to 6.1.0

Also updates Kotlin language and API versions to 2.2 in the pom.xml.